### PR TITLE
update base image to debian:stretch-backports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Start from debian:jessie-backports base.
-FROM debian:jessie-backports
+# Start from debian:stretch-backports base.
+FROM debian:stretch-backports
 
 # Prepare the image.
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
stretch-backports has compatible packages for newer 4.14 kernel.