### PR TITLE
Make cos-toolbox ARM compatible

### DIFF
--- a/cos-kernel
+++ b/cos-kernel
@@ -175,6 +175,8 @@ EOF
 
 
 main() {
+	check_arch
+
 	local options
 
 	parse_args "${@}"
@@ -206,6 +208,13 @@ main() {
 	esac
 }
 
+check_arch() {
+	arch=$(uname -m)
+	if  [ $arch == "arm64" ] || [ $arch == "aarch64" ]; then
+		echo "cos-kernel not supported on ARM"
+		exit 1
+	fi
+}
 
 parse_args() {
 	local args


### PR DESCRIPTION
Testing:
- Manually test Dockerfile build validity: Ran docker build ... && docker
run ... from root dir of project on x86_64/ arm64 (QEMU emulated) machines.
- Test multi-arch build validity of Dockerfile using `docker buildx`.
- Test docker image by pulling docker image on above machines created
using multi-arch build.
- Executed docker pull ... && docker run ... on above mentioned machines.

This change utilizes building docker-credential-gcr from source over
fetching from gcloud in light of missing ARM64 binaries for the same.